### PR TITLE
feat: turn on node pool autoprovisioning

### DIFF
--- a/cluster/Makefile
+++ b/cluster/Makefile
@@ -1,5 +1,5 @@
 # installer url
-PROW_INSTALLER_URL = https://github.com/ouzi-dev/prow-installer/releases/download/v1.4.0/prow-installer-v1.4.0.tar.gz
+PROW_INSTALLER_URL = https://github.com/ouzi-dev/prow-installer/releases/download/v1.6.0/prow-installer-v1.6.0.tar.gz
 
 # make sure make fails on shell errors 
 # caveat: does not work for the shell function

--- a/config/jobs/ouzi-dev/avro-kedavro/avro-kedavro.yaml
+++ b/config/jobs/ouzi-dev/avro-kedavro/avro-kedavro.yaml
@@ -12,6 +12,11 @@ presubmits:
           repo: test-infra
           base_ref: master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
           - image: gcr.io/k8s-prow/checkconfig:v20200220-16f6e7c89
             command:
@@ -27,6 +32,11 @@ presubmits:
       trigger: "(?m)validate-no-creds( please)?"
       rerun_command: "validate-no-creds"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
           - image: quay.io/ouzi/git-secret-scanner:0.0.3
             command:
@@ -43,6 +53,11 @@ presubmits:
       trigger: "(?m)test( please)?"
       rerun_command: "test"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
           - name: "test-avro-kedavro"
             imagePullPolicy: IfNotPresent
@@ -60,6 +75,11 @@ postsubmits:
       branches:
         - master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
           - name: "release-avro-kedavro"
             imagePullPolicy: IfNotPresent

--- a/config/jobs/ouzi-dev/bigbang/bigbang.yaml
+++ b/config/jobs/ouzi-dev/bigbang/bigbang.yaml
@@ -12,6 +12,11 @@ presubmits:
           repo: test-infra
           base_ref: master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
           - image: gcr.io/k8s-prow/checkconfig:v20200220-16f6e7c89
             command:
@@ -27,6 +32,11 @@ presubmits:
       trigger: "(?m)validate-no-creds( please)?"
       rerun_command: "validate-no-creds"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
           - image: quay.io/ouzi/git-secret-scanner:0.0.3
             command:
@@ -44,6 +54,11 @@ postsubmits:
       branches:
         - master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
           - name: "release-bigbang"
             imagePullPolicy: IfNotPresent

--- a/config/jobs/ouzi-dev/claptrap/claptrap.yaml
+++ b/config/jobs/ouzi-dev/claptrap/claptrap.yaml
@@ -12,6 +12,11 @@ presubmits:
           repo: test-infra
           base_ref: master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: gcr.io/k8s-prow/checkconfig:v20200220-16f6e7c89
           command:
@@ -27,6 +32,11 @@ presubmits:
       trigger: "(?m)validate-no-creds( please)?" 
       rerun_command: "validate-no-creds"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: quay.io/ouzi/git-secret-scanner:0.0.3
           command:

--- a/config/jobs/ouzi-dev/commit-status-updater/commit-status-updater.yaml
+++ b/config/jobs/ouzi-dev/commit-status-updater/commit-status-updater.yaml
@@ -12,6 +12,11 @@ presubmits:
           repo: test-infra
           base_ref: master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: gcr.io/k8s-prow/checkconfig:v20200220-16f6e7c89
           command:
@@ -27,6 +32,11 @@ presubmits:
       trigger: "(?m)validate-no-creds( please)?" 
       rerun_command: "validate-no-creds"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: quay.io/ouzi/git-secret-scanner:0.0.3
           command:

--- a/config/jobs/ouzi-dev/credstash-operator/credstash_operator.yaml
+++ b/config/jobs/ouzi-dev/credstash-operator/credstash_operator.yaml
@@ -12,6 +12,11 @@ presubmits:
           repo: test-infra
           base_ref: master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: gcr.io/k8s-prow/checkconfig:v20200220-16f6e7c89
           command:
@@ -27,6 +32,11 @@ presubmits:
       trigger: "(?m)validate-no-creds( please)?" 
       rerun_command: "validate-no-creds"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: quay.io/ouzi/git-secret-scanner:0.0.3
           command:

--- a/config/jobs/ouzi-dev/dind-action/dind-action.yaml
+++ b/config/jobs/ouzi-dev/dind-action/dind-action.yaml
@@ -12,6 +12,11 @@ presubmits:
           repo: test-infra
           base_ref: master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: gcr.io/k8s-prow/checkconfig:v20200220-16f6e7c89
           command:
@@ -27,6 +32,11 @@ presubmits:
       trigger: "(?m)validate-no-creds( please)?" 
       rerun_command: "validate-no-creds"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: quay.io/ouzi/git-secret-scanner:0.0.3
           command:

--- a/config/jobs/ouzi-dev/docs/docs.yaml
+++ b/config/jobs/ouzi-dev/docs/docs.yaml
@@ -12,6 +12,11 @@ presubmits:
           repo: test-infra
           base_ref: master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: gcr.io/k8s-prow/checkconfig:v20200220-16f6e7c89
           command:
@@ -27,6 +32,11 @@ presubmits:
       trigger: "(?m)validate-no-creds( please)?" 
       rerun_command: "validate-no-creds"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: quay.io/ouzi/git-secret-scanner:0.0.3
           command:

--- a/config/jobs/ouzi-dev/eks-terraform/eks-terraform.yaml
+++ b/config/jobs/ouzi-dev/eks-terraform/eks-terraform.yaml
@@ -12,6 +12,11 @@ presubmits:
           repo: test-infra
           base_ref: master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: gcr.io/k8s-prow/checkconfig:v20200220-16f6e7c89
           command:
@@ -27,6 +32,11 @@ presubmits:
       trigger: "(?m)validate-no-creds( please)?" 
       rerun_command: "validate-no-creds"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: quay.io/ouzi/git-secret-scanner:0.0.3
           command:

--- a/config/jobs/ouzi-dev/gke-terraform/gke-terraform.yaml
+++ b/config/jobs/ouzi-dev/gke-terraform/gke-terraform.yaml
@@ -12,6 +12,11 @@ presubmits:
           repo: test-infra
           base_ref: master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
           - image: gcr.io/k8s-prow/checkconfig:v20200220-16f6e7c89
             command:
@@ -27,6 +32,11 @@ presubmits:
       trigger: "(?m)validate-no-creds( please)?"
       rerun_command: "validate-no-creds"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
           - image: quay.io/ouzi/git-secret-scanner:0.0.3
             command:
@@ -44,6 +54,11 @@ postsubmits:
       branches:
         - master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
           - name: "release-gke-terraform"
             imagePullPolicy: IfNotPresent

--- a/config/jobs/ouzi-dev/go-make-action/go-make-action.yaml
+++ b/config/jobs/ouzi-dev/go-make-action/go-make-action.yaml
@@ -12,6 +12,11 @@ presubmits:
           repo: test-infra
           base_ref: master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: gcr.io/k8s-prow/checkconfig:v20200220-16f6e7c89
           command:
@@ -27,6 +32,11 @@ presubmits:
       trigger: "(?m)validate-no-creds( please)?" 
       rerun_command: "validate-no-creds"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: quay.io/ouzi/git-secret-scanner:0.0.3
           command:

--- a/config/jobs/ouzi-dev/hoarder-prow/hoarder-prow.yaml
+++ b/config/jobs/ouzi-dev/hoarder-prow/hoarder-prow.yaml
@@ -12,6 +12,11 @@ presubmits:
           repo: test-infra
           base_ref: master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: gcr.io/k8s-prow/checkconfig:v20200220-16f6e7c89
           command:
@@ -27,6 +32,11 @@ presubmits:
       trigger: "(?m)validate-no-creds( please)?" 
       rerun_command: "validate-no-creds"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: quay.io/ouzi/git-secret-scanner:0.0.3
           command:

--- a/config/jobs/ouzi-dev/node-tagger/node-tagger.yaml
+++ b/config/jobs/ouzi-dev/node-tagger/node-tagger.yaml
@@ -12,6 +12,11 @@ presubmits:
           repo: test-infra
           base_ref: master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: gcr.io/k8s-prow/checkconfig:v20200220-16f6e7c89
           command:
@@ -27,6 +32,11 @@ presubmits:
       trigger: "(?m)validate-no-creds( please)?" 
       rerun_command: "validate-no-creds"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: quay.io/ouzi/git-secret-scanner:0.0.3
           command:

--- a/config/jobs/ouzi-dev/ouzi.io/ouzi-io.yaml
+++ b/config/jobs/ouzi-dev/ouzi.io/ouzi-io.yaml
@@ -12,6 +12,11 @@ presubmits:
           repo: test-infra
           base_ref: master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: gcr.io/k8s-prow/checkconfig:v20200220-16f6e7c89
           command:
@@ -27,6 +32,11 @@ presubmits:
       trigger: "(?m)validate-no-creds( please)?" 
       rerun_command: "validate-no-creds"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: quay.io/ouzi/git-secret-scanner:0.0.3
           command:

--- a/config/jobs/ouzi-dev/owners-template/owners-template.yaml
+++ b/config/jobs/ouzi-dev/owners-template/owners-template.yaml
@@ -12,6 +12,11 @@ presubmits:
           repo: test-infra
           base_ref: master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: gcr.io/k8s-prow/checkconfig:v20200220-16f6e7c89
           command:
@@ -27,6 +32,11 @@ presubmits:
       trigger: "(?m)validate-no-creds( please)?" 
       rerun_command: "validate-no-creds"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: quay.io/ouzi/git-secret-scanner:0.0.3
           command:

--- a/config/jobs/ouzi-dev/prow-gke-terraform/prow-gke-terraform.yaml
+++ b/config/jobs/ouzi-dev/prow-gke-terraform/prow-gke-terraform.yaml
@@ -12,6 +12,11 @@ presubmits:
           repo: test-infra
           base_ref: master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
           - image: gcr.io/k8s-prow/checkconfig:v20200220-16f6e7c89
             command:
@@ -27,6 +32,11 @@ presubmits:
       trigger: "(?m)validate-no-creds( please)?"
       rerun_command: "validate-no-creds"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
           - image: quay.io/ouzi/git-secret-scanner:0.0.3
             command:
@@ -44,6 +54,11 @@ postsubmits:
       branches:
         - master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
           - name: "release-prow-gke-terraform"
             imagePullPolicy: IfNotPresent

--- a/config/jobs/ouzi-dev/prow-helm-chart/prow-helm-charts.yaml
+++ b/config/jobs/ouzi-dev/prow-helm-chart/prow-helm-charts.yaml
@@ -12,6 +12,11 @@ presubmits:
           repo: test-infra
           base_ref: master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: gcr.io/k8s-prow/checkconfig:v20200220-16f6e7c89
           command:
@@ -27,6 +32,11 @@ presubmits:
       trigger: "(?m)validate-no-creds( please)?" 
       rerun_command: "validate-no-creds"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: quay.io/ouzi/git-secret-scanner:0.0.3
           command:

--- a/config/jobs/ouzi-dev/prow-installer/prow-installer.yaml
+++ b/config/jobs/ouzi-dev/prow-installer/prow-installer.yaml
@@ -12,6 +12,11 @@ presubmits:
           repo: test-infra
           base_ref: master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: gcr.io/k8s-prow/checkconfig:v20200220-16f6e7c89
           command:
@@ -27,6 +32,11 @@ presubmits:
       trigger: "(?m)validate-no-creds( please)?" 
       rerun_command: "validate-no-creds"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: quay.io/ouzi/git-secret-scanner:0.0.3
           command:

--- a/config/jobs/ouzi-dev/syrinx/syrinx.yaml
+++ b/config/jobs/ouzi-dev/syrinx/syrinx.yaml
@@ -12,6 +12,11 @@ presubmits:
           repo: test-infra
           base_ref: master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: gcr.io/k8s-prow/checkconfig:v20200220-16f6e7c89
           command:
@@ -27,6 +32,11 @@ presubmits:
       trigger: "(?m)validate-no-creds( please)?" 
       rerun_command: "validate-no-creds"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: quay.io/ouzi/git-secret-scanner:0.0.3
           command:

--- a/config/jobs/ouzi-dev/test-infra/test-infra.yaml
+++ b/config/jobs/ouzi-dev/test-infra/test-infra.yaml
@@ -7,6 +7,11 @@ presubmits:
       trigger: "(?m)validate-no-creds( please)?" 
       rerun_command: "validate-no-creds"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: quay.io/ouzi/git-secret-scanner:0.0.3
           command:
@@ -23,7 +28,12 @@ presubmits:
       trigger: "(?m)test-prow-config( please)?" 
       rerun_command: "test-prow-config"
       run_if_changed: '^(config/.*|prow/.*)$'
-      spec: 
+      spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
           - name: "test-config"
             imagePullPolicy: IfNotPresent
@@ -44,7 +54,12 @@ presubmits:
       trigger: "(?m)monitoring( please)?" 
       rerun_command: "monitoring"
       run_if_changed: 'monitoring/'
-      spec: 
+      spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         serviceAccountName: prow
         containers:
           - name: "monitoring-dry-run"
@@ -66,7 +81,12 @@ presubmits:
       trigger: "(?m)test-infra( please)?" 
       rerun_command: "test-infra"
       run_if_changed: '^(infrastructure/.*)$'
-      spec: 
+      spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
           - name: "test-infra"
             imagePullPolicy: IfNotPresent
@@ -88,7 +108,12 @@ presubmits:
       trigger: "(?m)test-manifests( please)?" 
       rerun_command: "test-manifests"
       run_if_changed: '^(cluster/.*)$'
-      spec: 
+      spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         serviceAccountName: prow
         containers:
           - name: "test-manifests"
@@ -108,6 +133,11 @@ postsubmits:
       branches:
         - master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
           - name: "test-config"
             imagePullPolicy: IfNotPresent
@@ -125,7 +155,12 @@ postsubmits:
       run_if_changed: 'monitoring/'
       branches:
         - master
-      spec: 
+      spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         serviceAccountName: prow
         containers:
           - name: "monitoring"
@@ -149,7 +184,12 @@ postsubmits:
       run_if_changed: '^(infrastructure/.*)$'
       branches:
         - master
-      spec: 
+      spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
           - name: "apply-infra"
             imagePullPolicy: IfNotPresent
@@ -173,7 +213,12 @@ postsubmits:
       run_if_changed: '^(cluster/.*)$'
       branches:
         - master
-      spec: 
+      spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         serviceAccountName: prow
         containers:
           - name: "deploy-prow"

--- a/config/jobs/ouzi-dev/whalers-of-the-moon/whalers_of_the_moon.yaml
+++ b/config/jobs/ouzi-dev/whalers-of-the-moon/whalers_of_the_moon.yaml
@@ -12,6 +12,11 @@ presubmits:
           repo: test-infra
           base_ref: master
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: gcr.io/k8s-prow/checkconfig:v20200220-16f6e7c89
           command:
@@ -27,6 +32,11 @@ presubmits:
       trigger: "(?m)validate-no-creds( please)?" 
       rerun_command: "validate-no-creds"
       spec:
+        tolerations:
+          - effect: NoSchedule
+            key: cloud.google.com/gke-preemptible
+            operator: Equal
+            value: "true"
         containers:
         - image: quay.io/ouzi/git-secret-scanner:0.0.3
           command:

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -7,14 +7,14 @@ terraform {
 provider "google" {
   region      = var.gcloud_region
   project     = var.gcloud_project
-  version     = "3.8.0"
+  version     = "3.17.0"
   credentials = file(var.google_credentials_file_path)
 }
 
 provider "google-beta" {
   region      = var.gcloud_region
   project     = var.gcloud_project
-  version     = "3.8.0"
+  version     = "3.17.0"
   credentials = file(var.google_credentials_file_path)
 }
 
@@ -43,7 +43,7 @@ provider "random" {
 data "google_project" "project" {}
 
 module "prow-cluster" {
-  source = "github.com/ouzi-dev/prow-gke-terraform?ref=v0.10.0"
+  source = "github.com/ouzi-dev/prow-gke-terraform?ref=v0.11.1"
   # source = "../../prow-gke-terraform"
   gcloud_region              = var.gcloud_region
   gcloud_project             = var.gcloud_project

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -45,12 +45,12 @@ data "google_project" "project" {}
 module "prow-cluster" {
   source = "github.com/ouzi-dev/prow-gke-terraform?ref=v0.11.2"
   # source = "../../prow-gke-terraform"
-  gcloud_region              = var.gcloud_region
-  gcloud_project             = var.gcloud_project
-  gke_name                   = var.gke_name
-  gke_kubernetes_version     = var.gke_kubernetes_version
-  gke_min_nodes              = var.gke_min_nodes
-  gke_num_of_zones              = var.gke_num_of_zones
+  gcloud_region          = var.gcloud_region
+  gcloud_project         = var.gcloud_project
+  gke_name               = var.gke_name
+  gke_kubernetes_version = var.gke_kubernetes_version
+  gke_min_nodes          = var.gke_min_nodes
+  gke_num_of_zones       = var.gke_num_of_zones
 
   base_domain = var.base_domain
 
@@ -111,17 +111,17 @@ resource "google_project_service" "kms" {
 
 ### KMS key ring
 resource "google_kms_key_ring" "test_infra_key_ring" {
-  project  = var.gcloud_project
-  name     = "test-infra"
-  location = var.gcloud_region
-  depends_on = [ google_project_service.kms ]
+  project    = var.gcloud_project
+  name       = "test-infra"
+  location   = var.gcloud_region
+  depends_on = [google_project_service.kms]
 }
 
 ### KMS crypto key
 resource "google_kms_crypto_key" "build_crypto_key" {
-  name     = "build"
-  key_ring = google_kms_key_ring.test_infra_key_ring.self_link
-  depends_on = [ google_project_service.kms ]
+  name       = "build"
+  key_ring   = google_kms_key_ring.test_infra_key_ring.self_link
+  depends_on = [google_project_service.kms]
 }
 
 ### Set IAM for Cloud Builder Default Service Account

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -43,7 +43,7 @@ provider "random" {
 data "google_project" "project" {}
 
 module "prow-cluster" {
-  source = "github.com/ouzi-dev/prow-gke-terraform?ref=v0.11.1"
+  source = "github.com/ouzi-dev/prow-gke-terraform?ref=v0.11.2"
   # source = "../../prow-gke-terraform"
   gcloud_region              = var.gcloud_region
   gcloud_project             = var.gcloud_project

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -3,22 +3,22 @@ output "prow_bucket_name" {
 }
 
 output "prow_bucket_svc_account_key" {
-  value = module.prow-cluster.prow_bucket_svc_account_key
+  value     = module.prow-cluster.prow_bucket_svc_account_key
   sensitive = true
 }
 
 output "prow_terraform_gcloud_svc_account_key" {
-  value = module.prow-cluster.prow_terraform_gcloud_svc_account_key
+  value     = module.prow-cluster.prow_terraform_gcloud_svc_account_key
   sensitive = true
 }
 
 output "certmanager_svc_account_key" {
-  value = module.prow-cluster.certmanager_svc_account_key
+  value     = module.prow-cluster.certmanager_svc_account_key
   sensitive = true
 }
 
 output "preemptible_killer_svc_account_key" {
-  value = module.prow-cluster.preemptible_killer_key_svc_account_key
+  value     = module.prow-cluster.preemptible_killer_key_svc_account_key
   sensitive = true
 }
 
@@ -27,6 +27,6 @@ output "prow_credstash_reader_aws_access_key_id" {
 }
 
 output "prow_credstash_reader_aws_secret_access_key" {
-  value = aws_iam_access_key.prow_credstash_reader.secret
+  value     = aws_iam_access_key.prow_credstash_reader.secret
   sensitive = true
 }

--- a/infrastructure/terraform.tfvars
+++ b/infrastructure/terraform.tfvars
@@ -3,10 +3,10 @@ gcloud_project = "ouzidev-testinfra-252513"
 gke_name       = "spacepro-prowiverse"
 aws_region     = "eu-west-1"
 
-base_domain    = "test-infra.ouzi.io"
+base_domain = "test-infra.ouzi.io"
 
-gke_kubernetes_version = "1.14.8-gke.12"
-gke_min_nodes = 1
-gke_num_of_zones = 2
+gke_kubernetes_version                  = "1.14.8-gke.12"
+gke_min_nodes                           = 1
+gke_num_of_zones                        = 2
 gke_authenticator_groups_security_group = "gke-security-groups@ouzi.dev"
 prow_artefact_bucket_location           = "eu"


### PR DESCRIPTION
- [x] Delete all existing node pools and switch on [GKE node pool autoprovisioning ](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning)
- [x] Upgrade prow using the latest prow installer to take advantage of preemptible nodes


Node auto-provisioning works with node pools, it does not replace them. Therefore we are keeping the default node pool but we also support autoprovisioning pods have tolerations and node affinity/selectors