### PR TITLE
Revert "feat: require branches to be up to date with base"

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -70,8 +70,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -80,8 +78,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -90,8 +86,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -100,8 +94,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -110,8 +102,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -120,8 +110,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -130,8 +118,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -140,8 +126,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -150,8 +134,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -160,8 +142,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -170,8 +150,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -180,8 +158,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -190,8 +166,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -200,8 +174,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -210,8 +182,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -220,8 +190,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -230,8 +198,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -240,8 +206,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -250,8 +214,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -260,8 +222,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -270,8 +230,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot
@@ -280,8 +238,6 @@ branch-protection:
             master:
               protect: true # enable protection
               enforce_admins: true # rules apply to admins
-              required_status_checks: # Require branches to be up to date before merging.
-                strict: true
               restrictions: # restrict who can push to the repo
                 users:
                   - ouzibot


### PR DESCRIPTION
Reverts ouzi-dev/test-infra#112 

Based on https://github.com/kubernetes/test-infra/pull/17527#issuecomment-625246346:
```
This means that if GitHub repo has the "Require branches to be up-to-date before merging" setting enabled, and a PR is mergeable by git, but not up-to-date with master, then:

If you are using Tide, you should disable that setting. That setting is a hacky workaround for the fact that most (all?) of the other CI systems test a given PR once and consider its tests to be good if they succeeded once even though the base branch can move in the meantime, effectively invalidating the test result.

Tide however always does retesting and will only merge things that have green tests against the latest revision of the base branch. Hence, that setting isn't needed and as you noted may cause issues.
```